### PR TITLE
Update pelicanconf.py

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -69,7 +69,7 @@ NEST_SITEMAP_ATOM_LINK = u'Atom Feed'
 NEST_SITEMAP_RSS_LINK = u'RSS Feed'
 NEST_SOCIAL_COLUMN_TITLE = u'Social'
 NEST_LINKS_COLUMN_TITLE = u'Links'
-NEST_COPYRIGHT = u'<strong>&copy; 2015 Swiss Python Summit</strong>'
+NEST_COPYRIGHT = u'<strong>CC-BY-SA 2015 Swiss Python Summit</strong>'
 
 # Footer optional
 NEST_FOOTER_HTML = '<strong><a href="mailto:info@python-summit.ch">info@python-summit.ch</a></strong><br><br>'


### PR DESCRIPTION
copyright in the name of a summit is something that is probably not so easy to enforce... (well, copyright is normally attributed to persons... eventually to registered companies/associations...).

but even then, it would be nice to have a cc-by(-sa) notice, instead of a (c)...
